### PR TITLE
Set flavour of PDO statement

### DIFF
--- a/src/ODBCConnector.php
+++ b/src/ODBCConnector.php
@@ -54,6 +54,9 @@ class ODBCConnector extends Connector implements ConnectorInterface, OdbcDriver
     {
         return function ($connection, $database, $prefix, $config) {
             $connection = (new self())->connect($config);
+            if ($flavour = Arr::get($config, 'options.flavour')) {
+                $connection->setAttribute(PDO::ATTR_STATEMENT_CLASS, [$flavour, [$connection]]);
+            }
             $connection = new ODBCConnection($connection, $database, $prefix, $config);
 
             return $connection;


### PR DESCRIPTION
There are statement flavours for Snowflake that can be set on the connection, and we're using this code in our own codebase to connect to Databricks. The code does not work without this. I picked what seems to me to be a reasonable configuration to use in Laravel, e.g. our current working one for Databricks SQL:

```php
$connections = [
        'databricks' => [
            'dsn'      => env('DB_DATABRICKS_DSN', null),
            'driver'   => 'odbc',
            'username' => 'token',
            'password' => env('DB_DATABRICKS_TOKEN', null),
            'database' => 'mysql_foobar',

            'options' => [
                'processor' => Illuminate\Database\Query\Processors\MySqlProcessor::class,
                'grammar'   => [
                    'query'  => Illuminate\Database\Query\Grammars\MySqlGrammar::class,
                    'schema' => Illuminate\Database\Schema\Grammars\MySqlGrammar::class,
                ],
                'flavour' => \LaravelPdoOdbc\Flavours\Snowflake\PDO\Statement80::class,
                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_OBJ,
            ],
        ],
];
```

If the key or anything else seems like it should be something different just lmk and I'll get it resolved.