### PR TITLE
Explicit Integer Check for Statement Binding Preparation

### DIFF
--- a/src/Flavours/Snowflake/Connection.php
+++ b/src/Flavours/Snowflake/Connection.php
@@ -61,7 +61,7 @@ class Connection extends ODBCConnection
             $type = PDO::PARAM_STR;
             if (is_bool($value)) {
                 $value = $value ? 'TRUE' : 'FALSE';
-            } elseif (is_numeric($value)) {
+            } elseif (is_int($value)) {
                 $type = PDO::PARAM_INT;
             }
 
@@ -92,7 +92,7 @@ class Connection extends ODBCConnection
                 $bindings[$key] = (bool) $value;
             } elseif (is_float($value)) {
                 $bindings[$key] = (float) $value;
-            } elseif (is_numeric($value)) {
+            } elseif (is_int($value)) {
                 $bindings[$key] = (int) $value;
             }
         }


### PR DESCRIPTION
This PR provides a fix for a slightly too wide `is_numeric` logic when preparing bindings.

The current implementation will take any kind of numeric value and convert it to an integer. This could be a numeric-like string, float or integer.

This leads to problems:

1. In my case I found it because we insert numeric-like strings to a varchar column. Under the correct logic these were parsed to integers and unquoted in the insert SQL which Snowflake complains fatally about (integer into a string column).
2. It would also mistakenly convert floats as strings to int's, which is also not desirable.

The fix here simply does away with this logic by only applying the integer logic if the value is actually an integer, and not a numeric-like string.

It would cause a breaking issue for applications currently sending a string to an integer column, relying on this behavior. But that would more reasonably be fixed by the application casting to a string when preparing the data to insert instead of in here.