### PR TITLE
fix: fixed syntax error

### DIFF
--- a/src/Flavours/Snowflake/Connector.php
+++ b/src/Flavours/Snowflake/Connector.php
@@ -55,7 +55,7 @@ class Connector extends ODBCConnector implements OdbcDriver
             // create connection
             $db = new Connection($connection, $database, $prefix, $config);
             if (!env('SNOWFLAKE_DISABLE_FORCE_QUOTED_IDENTIFIER')) {
-                $connection->exec('ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = false'));
+                $connection->exec('ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = false');
             }
             
             // set default fetch mode for PDO


### PR DESCRIPTION
You had a syntax error in the Flavours/Snowflake/Connector.php

Also, when you published the new v2.0.0 tag, its not updating packagist. I assume this could have something to do with the vendor repo name changing.

On packagist, it's listed as [yoramdelangen/](https://packagist.org/packages/yoramdelangen/)laravel-pdo-odbc but I had to install this with `"appsfortableau/laravel-pdo-odbc": "dev-main"`. I'm not sure what the fix is for publishing, but my fork does fix the syntax error and confirm this works for Laravel 12.