### PR TITLE
Fix `compileTruncate` return type and SQL typo.

### DIFF
--- a/src/Flavours/Snowflake/Grammars/Query.php
+++ b/src/Flavours/Snowflake/Grammars/Query.php
@@ -137,7 +137,7 @@ class Query extends Grammar
      */
     public function compileTruncate(Builder $query)
     {
-        return 'trunate table '.$this->wrapTable($query->from);
+        return ['truncate table '.$this->wrapTable($query->from) => []];
     }
 
     /**


### PR DESCRIPTION
The method annotation expects an array to be returned. The SQL executed by the method also had a typo.

### Return Type Issue
Reproduce:
```php
// Truncate a model using a snowflake connection
Country::on('snowflake')->truncate();
```
Result:
```
Psy Shell v0.11.15 (PHP 8.2.28 — cli) by Justin Hileman
> Country::on('snowflake')->truncate();

   WARNING  foreach() argument must be of type array|object, string given in vendor/laravel/framework/src/Illuminate/Database/Query/Builder.php on line 3585.

= Illuminate\Database\Eloquent\Builder {#8554}
```
Solution:
```
Return an array to fix the warning.
```

### SQL Typo Issue
Reproduce (after fixing previous issue):
```php
// Truncate a model using a snowflake connection
Country::on('snowflake')->truncate();
```
Result:
```
Psy Shell v0.11.15 (PHP 8.2.28 — cli) by Justin Hileman
> Country::on('snowflake')->truncate();

   Illuminate\Database\QueryException  SQLSTATE[42000]: Syntax error or access violation: 1003 SQL compilation error:
syntax error line 1 at position 0 unexpected 'trunate'. (Connection: snowflake, SQL: trunate table "countries").
```
Solution:
```
Replace typo `trunate` with `truncate`.
```